### PR TITLE
Allow defining file directives in a rpm package

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function prepareFiles(files, excludeFiles, buildRoot) {
       var dest = path.join(file.dest, copyTarget);
 
       if(checkDirective(file.directive))
-        _files.push({file: dest, directive: file.directive});
+        _files.push({path: dest, directive: file.directive});
       else
         throw new Error('Invalid file directive informed: ' + file.directive);
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,12 @@ function retrieveFilesToExclude(excludeFiles) {
   });
 }
 
+function checkDirective(directive) {
+  if(directive == undefined)
+    return true;
+  return directive.match(/^(?:doc|config|attr|verify|docdir|dir)/);
+}
+
 /**
  * 1. Normalize and expand the patterns/files (specified by the user)
  *    that should be included in the RPM package.
@@ -84,7 +90,12 @@ function prepareFiles(files, excludeFiles, buildRoot) {
       // relative to the cwd
       var copyTarget = path.normalize(srcFile).replace(path.normalize(file.cwd), '');
       var dest = path.join(file.dest, copyTarget);
-      _files.push(dest);
+
+      if(checkDirective(file.directive))
+        _files.push({file: dest, directive: file.directive});
+      else
+        throw new Error('Invalid file directive informed: ' + file.directive);
+
       fsx.copySync(srcFile, path.join(buildRoot, dest));
     });
   });

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -163,7 +163,8 @@ module.exports = function(files, options) {
 
   b.push('%files');
   _.forEach(files, function(file) {
-    b.push('"' + file + '"');
+    var directive = (file.directive == undefined) ? '' : '%' + file.directive + ' ';
+    b.push(directive + '"' + file + '"');
   });
 
   var specFileContent = b.join('\n');

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -164,7 +164,7 @@ module.exports = function(files, options) {
   b.push('%files');
   _.forEach(files, function(file) {
     var directive = (file.directive == undefined) ? '' : '%' + file.directive + ' ';
-    b.push(directive + '"' + file + '"');
+    b.push(directive + '"' + file.path + '"');
   });
 
   var specFileContent = b.join('\n');

--- a/test/spec.js
+++ b/test/spec.js
@@ -40,9 +40,9 @@ describe('spec', function() {
   describe('spec output', function() {
     var specFile;
     var files = [
-      path.join(__dirname, 'index.js'),
-      path.join(__dirname, 'package.json'),
-      path.join(__dirname, 'README.md')
+      {path: path.join(__dirname, 'index.js')},
+      {path: path.join(__dirname, 'package.json')},
+      {path: path.join(__dirname, 'README.md'), directive: 'config'}
     ];
     var options = {
       name: 'test',
@@ -113,7 +113,11 @@ describe('spec', function() {
     it('should have all files defined', function(done) {
       fsx.readFile(specFile, {encoding: 'utf-8'}, function(err, data) {
         files.forEach(function(file) {
-          assert(data.indexOf(file) > -1);
+          assert(data.indexOf(file.path) > -1);
+          if(file.hasOwnProperty('directive')) {
+            var directiveLine = '%config "' + file.path + '"';
+            assert(data.indexOf(directiveLine) > -1);
+          }
         });
         done();
       });


### PR DESCRIPTION
Hey, its me again bothering you!

I needed to define specific directives to a given group of files, so I added support for such feature in the node-rpm-builder. More info about directives [here](http://www.rpm.org/max-rpm/s1-rpm-inside-files-list-directives.html)

Basically, it should work something like this:

```javascript
options = { /* initial data */ }
options.files.push({
    src: "path/to/file",
    dest: "file/destination/path",
    directive: "config" // the '%' is included automatically
});

buildRpm(options, cb);
```

In this example, the following line would be generated on the rpm spec file:

```bash
%config "file/destination/path"
```

Needless to say, files without directives keep working normally. Currently, there is support for the `%config`, `%doc`, `%docdir`, `%attr` and `%verify` and `%dir` directives.

Interested?