### PR TITLE
Adding targetOs option to define _target_os in rpm spec

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -19,6 +19,7 @@ module.exports = function(files, options) {
   var b = [];
 
   b.push('%define   _topdir ' + path.resolve(options.tempDir));
+  b.push('%define   _target_os ' + options.targetOs);
   b.push('');
   b.push('Name: ' + options.name);
   b.push('Version: ' + options.version);


### PR DESCRIPTION
# Issue

There were no way to set `_target_os` in spec.
In case user want to make rpm in osx to install linux, it fails due to this.
# Fix

Adding option `targetOs` to set `_target_os` in spec.
# Example

```
                    var options = {
                        name: 'testrpm',
                        version: '0.0.1',
                        release: '1',
                        buildArch: 'noarch',
                        targetOs: 'linux'
                    };
```
