### PR TITLE
Enhanced function exclude files

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function checkDirective(directive) {
  *
  * @param  {String} src     source file for copy
  */
-const filterExcludeFile = (src) => {
+var filterExcludeFile = function filterFunc(src){
   if (filesToExclude.indexOf(src) > -1) {
     return false;
   }


### PR DESCRIPTION
# ISSUE
If I have this tree for shortid folder
```
node_modules/shortid/
├── Gruntfile.js
├── index.js
├── lib
│   ├── alphabet.js
│   ├── decode.js
│   ├── encode.js
│   ├── index.js
│   ├── is-valid.js
│   ├── otherDir
│   │   └── otherfile
│   ├── random
│   │   ├── random-byte-browser.js
│   │   ├── random-byte.js
│   │   └── random-from-seed.js
│   └── util
│       ├── cluster-worker-id-browser.js
│       └── cluster-worker-id.js
├── LICENSE
├── package.json
└── README.md
```
with this options:   
```
var buildRpm = require('./');

var options = {
  name: 'test2',
  files: [
    {src: 'index.js', dest: '/dist/'},
    {src: './lib/*', dest: '/dist/'},
    {cwd: './node_modules/', src: 'shortid/lib/*', dest: '/dist/'},
    {cwd: './node_modules/', src: 'async/*', dest: '/dist/'}
  ],
  excludeFiles: [
    './node_modules/shortid/lib/alphabet.js',
    './node_modules/shortid/lib/otherDir/otherFile',
    './node_modules/async/*.json'
  ],
  tempDir: 'rpm2',
  keepTemp: true,
  verbose: true,
  // rpmDest: '/home/vagrant',

  url: 'http://rictorres.com',
  requires: ['node', 'npm'],
  postInstallScript: [
    'chown -R sitestat:sitestat $RPM_INSTALL_PREFIX/renderer',
    'chmod +x $RPM_INSTALL_PREFIX/renderer/nodejs/bin/*',
    'chmod +x $RPM_INSTALL_PREFIX/renderer/phantomjs/bin/*'
  ]
  // buildRequires: ['node > 0.9.0', 'npm > 1.4']
};
```
"Otherfile" is not excluded because it compares to the files and folders of the first level of "/node_modules/shortid/lib/" 
# FIX
To solve this problem I added the filtering option to the copysync function: 
```
  fsx.copySync(srcFile, path.join(buildRoot, dest),{ filter: filterExcludeFile });
```
```
var filterExcludeFile = function filterFunc(src){
  if (filesToExclude.indexOf(src) > -1) {
    return false;
  }
  return true;
};
```
