### PR TITLE
Add `Changelog` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,41 @@ An array specifying _only_ the architectures the RPM should build on (e.g. `["x8
 
 List of packages required for building (compiling) the program. You can specify a minimum version if necessary (e.g. `["ocaml >= 3.08"]`).
 
+### changelog
+`Array`
+
+An array of changelog entries in format:
+
+```
+{
+  date: Date,
+  author: String,
+  changes: Array<String>,
+}
+```
+
+*Example*
+
+```
+const changelog = [
+  {
+    date: new Date('1995-12-17T03:24:00'),
+    author: 'John Foo <john@foo.com>',
+    changes: [
+      'updated core library to 1.5.2',
+      'fixed API method `listUserContacts`'
+    ]
+  },
+  {
+    date: new Date('1995-12-19T03:24:00'),
+    author: 'John Foo <john@foo.com>',
+    changes: [
+      'established DB queries cache'
+    ]
+  }
+];
+```
+
 #### prepScript
 `Array`
 

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -3,6 +3,11 @@
 var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
+var dateFormat = require('dateformat');
+
+function formatChangelogDate(date) {
+  return dateFormat(date, 'ddd mmm dd yyyy');
+}
 
 module.exports = function(files, options) {
   if (!files || !Array.isArray(files)) {
@@ -170,6 +175,22 @@ module.exports = function(files, options) {
     var directive = (typeof file.directive === 'undefined') ? '' : '%' + file.directive + ' ';
     b.push(directive + '"' + file.path + '"');
   });
+
+  if (options.changelog && Array.isArray(options.changelog) && options.changelog.length > 0) {
+    b.push('');
+    b.push('%changelog');
+
+    options.changelog
+      .forEach(function(entry, index) {
+        if (index > 0) {
+          b.push('');
+        }
+        b.push('* ' + formatChangelogDate(entry.date) + ' ' + entry.author);
+        entry.changes.forEach(function(change) {
+          b.push('- ' + change);
+        });
+      });
+  }
 
   var specFileContent = b.join('\n');
   fs.writeFileSync(specFile, specFileContent);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpm-builder",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Build RPM packages using Node.js",
   "license": "MIT",
   "homepage": "https://github.com/rictorres/node-rpm-builder",
@@ -40,9 +40,10 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "chalk": "^0.5.1",
+    "dateformat": "^2.0.0",
     "fs-extra": "^0.16.3",
     "globby": "^1.1.0",
-    "lodash": "^3.2.0",
+    "lodash": "^4.17.4",
     "shortid": "^2.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpm-builder",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Build RPM packages using Node.js",
   "license": "MIT",
   "homepage": "https://github.com/rictorres/node-rpm-builder",


### PR DESCRIPTION
Provide list of changelog entries for generated RPM.

https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch22s05.html