### PR TITLE
Remove verbose switch from rpmbuild execution

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,6 @@ function buildRpm(buildRoot, specFile, rpmDest, execOpts, cb) {
   var cmd = [
     'rpmbuild',
     '-bb',
-    '-vv',
     '--buildroot',
     buildRoot,
     specFile


### PR DESCRIPTION
- when attempting to build an RPM of modest size, the buffer is exceeded
  due to the massive logging dumped onto the stderr by the `-vv` switch
- the logs provided by the option were not helpful and only prevented
  builds from completing