### PR TITLE
Use nanoid directly instead of using shortid

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var chalk = require('chalk');
 var exec = require('child_process').exec;
 var fsx = require('fs-extra');
 var globby = require('globby');
+var nanoid = require('nanoid');
 var path = require('path');
-var shortid = require('shortid');
 var _ = require('lodash');
 
 var writeSpec = require('./lib/spec');
@@ -172,7 +172,7 @@ function rpm(options, cb) {
     vendor: 'Vendor',
     group: 'Development/Tools',
     buildArch: 'noarch',
-    tempDir: 'tmp-' + shortid.generate(),
+    tempDir: 'tmp-' + nanoid.nanoid(16),
     files: [],
     excludeFiles: [],
     rpmDest: process.cwd(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,9 +740,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
-      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -856,14 +856,6 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
-      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
-      "requires": {
-        "nanoid": "^2.0.0"
-      }
     },
     "sigmund": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fs-extra": "^1.0.0",
     "globby": "^6.1.0",
     "lodash": "^4.17.4",
-    "shortid": "^2.1.3"
+    "nanoid": "^3.2.0"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/test/main.js
+++ b/test/main.js
@@ -6,8 +6,8 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 var fsx = require('fs-extra');
 var globby = require('globby');
+var nanoid = require('nanoid');
 var path = require('path');
-var shortid = require('shortid');
 var _ = require('lodash');
 
 var buildRpm = require('../');
@@ -54,7 +54,7 @@ describe('rpm builder', function() {
 
     it('should keep the temp folder when `keepTemp: true`', function(done) {
       var options = {
-        tempDir: 'rpm-builder-test-tmp-' + shortid.generate(),
+        tempDir: 'rpm-builder-test-tmp-' + nanoid.nanoid(16),
         keepTemp: true
       };
 
@@ -78,7 +78,7 @@ describe('rpm builder', function() {
 
     it('should remove the temp folder when `keepTemp: false`', function(done) {
       var options = {
-        tempDir: 'rpm-builder-test-tmp-' + shortid.generate(),
+        tempDir: 'rpm-builder-test-tmp-' + nanoid.nanoid(16),
         keepTemp: false
       };
 
@@ -100,7 +100,7 @@ describe('rpm builder', function() {
     it('should create a proper rpm folder structure inside the temp dir', function(done) {
       var rpmStructure = ['BUILD', 'BUILDROOT', 'RPMS', 'SOURCES', 'SPECS', 'SRPMS'];
       var options = {
-        tempDir: 'rpm-builder-test-tmp-' + shortid.generate(),
+        tempDir: 'rpm-builder-test-tmp-' + nanoid.nanoid(16),
         keepTemp: true
       };
 
@@ -131,7 +131,7 @@ describe('rpm builder', function() {
 
     it('rpm file should be copied to the `rpmDest`', function(done) {
       var options = {
-        tempDir: 'rpm-builder-test-tmp-' + shortid.generate(),
+        tempDir: 'rpm-builder-test-tmp-' + nanoid.nanoid(16),
         rpmDest: path.join(process.cwd(), 'test'),
         keepTemp: false
       };
@@ -156,7 +156,7 @@ describe('rpm builder', function() {
         version: '23.02.87',
         release: '28',
         buildArch: 'noarch',
-        tempDir: 'rpm-builder-test-tmp-' + shortid.generate(),
+        tempDir: 'rpm-builder-test-tmp-' + nanoid.nanoid(16),
         keepTemp: false
       };
 
@@ -191,7 +191,7 @@ describe('rpm builder', function() {
         excludeFiles: [
           './test/main.js'
         ],
-        tempDir: 'rpm-builder-test-tmp-' + shortid.generate(),
+        tempDir: 'rpm-builder-test-tmp-' + nanoid.nanoid(16),
         keepTemp: true
       };
 

--- a/test/spec.js
+++ b/test/spec.js
@@ -4,8 +4,8 @@
 
 var assert = require('assert');
 var fsx = require('fs-extra');
+var nanoid = require('nanoid');
 var path = require('path');
-var shortid = require('shortid');
 var _ = require('lodash');
 var dateFormat = require('dateformat');
 
@@ -57,7 +57,7 @@ describe('spec', function() {
       vendor: 'Vendor',
       group: 'Development/Tools',
       buildArch: 'noarch',
-      tempDir: 'tmp-' + shortid.generate(),
+      tempDir: 'tmp-' + nanoid.nanoid(16),
       files: [],
       keepTemp: false
     };


### PR DESCRIPTION
Shortid is deprecated and the project recommends using nanoid directly.

Also all published versions of shortid rely on older versions of nanoid
that contain known security issues and should be avoided.

This removes the use of shortid and instead directly uses the latest
version of nanoid that does not contain known security vulnerabilities.